### PR TITLE
Fix example usage of preprocessed internet traffic dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,10 @@ dict_keys(['y', 'x', 'note'])
 (1142626, 11)
 >>> data['x'][0][:8]        # source ip (first 4) and destination ip (last 4)
 array([ 198.,  115.,   14.,  163.,    1.,   91.,  194.,    1.])
->>> data['x'][0][8:10]      # source port and destination port
-array([     6.,  35059.])
->>> data['x'][0][-1]        # protocol type
-22.0
+>>> data['x'][0][8]         # protocol type
+6.0
+>>> data['x'][0][9:]        # source port and destination port
+array([35059.,    22.])
 >>> data['y'][0]            # number of packets
 153733
 ```


### PR DESCRIPTION
Looking at the [the code](https://github.com/chenyuhsu/learnedsketch/blob/master/utils/utils.py#L25)
```python
def format_data_wports(data_x, n_examples):
    data_ip = decimal2binary(data_x[:n_examples, np.arange(8)])
    data_proto = data_x[:n_examples, 8].reshape(-1, 1)
    data_srcport = uint16_to_binary(data_x[:n_examples, 9].reshape(-1, 1))
    data_dstport = uint16_to_binary(data_x[:n_examples, 10].reshape(-1, 1))
    return np.concatenate((data_ip, data_srcport, data_dstport, data_proto), axis=1)
```
it seems like the order described in the example python code in the README switched port and protocol type.

This pull request adds the correct field order description to the README.